### PR TITLE
TST: Use hypothesis to test anticommutativity of cross2d.

### DIFF
--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -8,6 +8,7 @@ import traceback
 import textwrap
 import subprocess
 import pytest
+from hypothesis import given, strategies as st
 
 import numpy as np
 from numpy import array, single, double, csingle, cdouble, dot, identity, matmul
@@ -2324,14 +2325,17 @@ class TestCross2d:
 
         assert_equal(actual, expected)
 
-    def test_2x2_anticommutativity(self):
-        u = [1, 2]
-        v = [3, 4]
-        z = -2
-        cp = np.linalg.cross2d(u, v)
-        assert_equal(cp, z)
-        cp = np.linalg.cross2d(v, u)
-        assert_equal(cp, -z)
+    @given(
+        st.lists(
+            st.one_of(st.integers(-10**9, 10**9), st.floats()), min_length=4, max_length=4
+        )
+    )
+    def test_2x2_anticommutativity(self, concatenated_vectors):
+        u = concatenated_vectors[:2]
+        v = concatenated_vectors[2:]
+        forward = np.linalg.cross2d(u, v)
+        reverse = np.linalg.cross2d(v, u)
+        assert_equal(forward, -reverse)
 
     def test_broadcasting(self):
         # Ticket #2624 (Trac #2032)


### PR DESCRIPTION
There's already hypothesis-based tests in the suite, and $\vec{a}\times \vec{b} = -\vec{b}\times \vec{a}$ is the kind of property hypothesis is good at verifying.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
